### PR TITLE
fix: re-enforce clipboard protection after snooze expiry

### DIFF
--- a/cmd/guardmycopy/launch_agent.go
+++ b/cmd/guardmycopy/launch_agent.go
@@ -30,6 +30,7 @@ type launchAgentDeps struct {
 	runtimeOS    string
 	templatePath string
 	templateData []byte
+	timeNow      func() time.Time
 	executable   func() (string, error)
 	cwd          func() (string, error)
 	homeDir      func() (string, error)
@@ -53,6 +54,9 @@ func (d launchAgentDeps) withDefaults() launchAgentDeps {
 	}
 	if len(d.templateData) == 0 {
 		d.templateData = embeddedLaunchAgentTemplate
+	}
+	if d.timeNow == nil {
+		d.timeNow = time.Now
 	}
 	if d.executable == nil {
 		d.executable = os.Executable
@@ -216,10 +220,7 @@ func runStatusWithIO(args []string, stdout, stderr io.Writer, deps launchAgentDe
 		return 1
 	}
 
-	snoozedUntil := "none"
-	if !state.SnoozedUntil.IsZero() {
-		snoozedUntil = state.SnoozedUntil.Format(time.RFC3339)
-	}
+	snoozedUntil := formatActiveSnoozedUntil(state, deps.timeNow())
 
 	fmt.Fprintf(stdout, "launch-agent-loaded=%t\n", loaded)
 	fmt.Fprintf(stdout, "launch-agent-running=%t\n", running)
@@ -238,6 +239,14 @@ func runStatusWithIO(args []string, stdout, stderr io.Writer, deps launchAgentDe
 		fmt.Fprintf(stdout, "foreground-app-error=%q\n", appErr.Error())
 	}
 	return 0
+}
+
+func formatActiveSnoozedUntil(state userstate.State, now time.Time) string {
+	snoozedUntil, ok := state.ActiveSnoozedUntil(now)
+	if !ok {
+		return "none"
+	}
+	return snoozedUntil.Format(time.RFC3339)
 }
 
 func installLaunchAgent(stdout io.Writer, deps launchAgentDeps) error {

--- a/cmd/guardmycopy/launch_agent_test.go
+++ b/cmd/guardmycopy/launch_agent_test.go
@@ -299,6 +299,9 @@ func TestRunStatusWithIOReportsLoadedRunningAndBypass(t *testing.T) {
 	var launchctlCalls [][]string
 	deps := launchAgentDeps{
 		runtimeOS: "darwin",
+		timeNow: func() time.Time {
+			return snoozedUntil.Add(-time.Minute)
+		},
 		uid: func() int {
 			return 501
 		},
@@ -340,6 +343,47 @@ func TestRunStatusWithIOReportsLoadedRunningAndBypass(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), `foreground-app-bundle-id="com.google.Chrome"`) {
 		t.Fatalf("expected foreground bundle id, got %q", stdout.String())
+	}
+}
+
+func TestRunStatusWithIOIgnoresExpiredSnooze(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	store, err := userstate.New(statePath)
+	if err != nil {
+		t.Fatalf("new userstate store: %v", err)
+	}
+	now := time.Unix(1_700_000_000, 0).UTC()
+	if err := store.Save(userstate.State{
+		SnoozedUntil: now.Add(-time.Minute),
+		AllowOnce:    true,
+	}); err != nil {
+		t.Fatalf("save userstate: %v", err)
+	}
+
+	deps := launchAgentDeps{
+		runtimeOS: "darwin",
+		timeNow: func() time.Time {
+			return now
+		},
+		runLaunchctl: func(args ...string) (string, error) {
+			return "state = running\npid = 123", nil
+		},
+		activeApp: func() (string, string, error) {
+			return "Google Chrome", "com.google.Chrome", nil
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runStatusWithIO(nil, &stdout, &stderr, deps, statePath)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "snoozed-until=none") {
+		t.Fatalf("expected expired snooze to report as none, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "allow-once=true") {
+		t.Fatalf("expected allow-once=true to remain visible, got %q", stdout.String())
 	}
 }
 

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -242,6 +242,7 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 	var lastSeenHash [32]byte
 	var lastSeenAppContext activeAppContext
 	var lastSeenChangeCount int64
+	var lastSeenSnoozeActive bool
 	seen := false
 	for {
 		select {
@@ -252,6 +253,11 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 			if err != nil {
 				return err
 			}
+			state, err := s.loadRuntimeState()
+			if err != nil {
+				return err
+			}
+			snoozeActive := state.SnoozeActive(s.timeNow())
 
 			appResolution := activeAppResolution{
 				status: AppContextStatusUnavailable,
@@ -260,7 +266,7 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 			if seen && hasChangeCount && currentChangeCount == lastSeenChangeCount {
 				appResolution = s.resolveActiveApp()
 				appResolutionLoaded = true
-				if appResolution.context == lastSeenAppContext {
+				if appResolution.context == lastSeenAppContext && snoozeActive == lastSeenSnoozeActive {
 					timer.Reset(polling.OnClipboardUnchanged())
 					continue
 				}
@@ -274,7 +280,10 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 			if !appResolutionLoaded {
 				appResolution = s.resolveActiveApp()
 			}
-			if seen && currentHash == lastSeenHash && appResolution.context == lastSeenAppContext {
+			clipboardOrAppChanged := !seen ||
+				currentHash != lastSeenHash ||
+				appResolution.context != lastSeenAppContext
+			if !clipboardOrAppChanged && snoozeActive == lastSeenSnoozeActive {
 				if hasChangeCount {
 					lastSeenChangeCount = currentChangeCount
 				}
@@ -284,12 +293,13 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 			seen = true
 			lastSeenHash = currentHash
 			lastSeenAppContext = appResolution.context
+			lastSeenSnoozeActive = snoozeActive
 			if hasChangeCount {
 				lastSeenChangeCount = currentChangeCount
 			}
 			nextInterval := polling.OnClipboardChanged()
 
-			bypass, bypassReason, err := s.shouldBypassEnforcement()
+			bypass, bypassReason, err := s.shouldBypassEnforcementWithState(state, clipboardOrAppChanged)
 			if err != nil {
 				return err
 			}
@@ -333,10 +343,6 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 			timer.Reset(nextInterval)
 		}
 	}
-}
-
-func (s *Service) decide(text string) (PolicyDecision, policyResult) {
-	return s.decideWithActiveAppResolution(text, s.resolveActiveApp())
 }
 
 func (s *Service) decideWithActiveAppResolution(
@@ -620,28 +626,46 @@ func cloneActions(input map[core.RiskLevel]config.Action) map[core.RiskLevel]con
 	return out
 }
 
-func (s *Service) shouldBypassEnforcement() (bool, string, error) {
+func (s *Service) loadRuntimeState() (userstate.State, error) {
 	if s.stateStore == nil {
-		return false, "", nil
+		return userstate.State{}, nil
 	}
 
 	state, err := s.stateStore.Load()
 	if err != nil {
-		return false, "", fmt.Errorf("load runtime state: %w", err)
+		return userstate.State{}, fmt.Errorf("load runtime state: %w", err)
+	}
+	return state, nil
+}
+
+func (s *Service) shouldBypassEnforcement() (bool, string, error) {
+	state, err := s.loadRuntimeState()
+	if err != nil {
+		return false, "", err
+	}
+	return s.shouldBypassEnforcementWithState(state, true)
+}
+
+func (s *Service) shouldBypassEnforcementWithState(
+	state userstate.State,
+	allowOnceEligible bool,
+) (bool, string, error) {
+	if s.stateStore == nil {
+		return false, "", nil
 	}
 
 	now := s.timeNow()
-	if !state.SnoozedUntil.IsZero() && state.SnoozedUntil.After(now) {
-		return true, fmt.Sprintf("snoozed until %s", state.SnoozedUntil.Local().Format(time.RFC3339)), nil
+	if snoozedUntil, ok := state.ActiveSnoozedUntil(now); ok {
+		return true, fmt.Sprintf("snoozed until %s", snoozedUntil.Local().Format(time.RFC3339)), nil
 	}
 
 	dirty := false
-	if !state.SnoozedUntil.IsZero() && !state.SnoozedUntil.After(now) {
+	if !state.SnoozedUntil.IsZero() {
 		state.SnoozedUntil = time.Time{}
 		dirty = true
 	}
 
-	if state.AllowOnce {
+	if state.AllowOnce && allowOnceEligible {
 		state.AllowOnce = false
 		dirty = true
 		if err := s.stateStore.Save(state); err != nil {

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -529,6 +529,65 @@ func TestRunRespectsAllowOnceState(t *testing.T) {
 	}
 }
 
+func TestRunReenforcesWhenSnoozeExpiresWithoutClipboardOrAppChange(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	snoozedUntil := now.Add(time.Minute)
+
+	clip := &mockClipboardWithChangeDetector{
+		mockClipboard: &mockClipboard{
+			value: "start\n-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\nend",
+		},
+		changeCounts: []int64{7, 7, 8},
+	}
+	notifier := &mockNotifier{}
+	foreground := &mockForegroundApp{name: "Slack", bundleID: "com.tinyspeck.slackmacgap"}
+	stateStore := &mockRuntimeStateStore{
+		state: userstate.State{
+			SnoozedUntil: snoozedUntil,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clip.changeCountHook = func(call int) {
+		switch call {
+		case 2:
+			now = snoozedUntil.Add(time.Millisecond)
+		case 3:
+			cancel()
+			clip.changeCountHook = nil
+		}
+	}
+
+	svc := NewWithDependencies(config.Defaults(), clip, foreground, notifier)
+	svc.timeNow = func() time.Time { return now }
+	svc.SetRuntimeStateStore(stateStore)
+
+	err := svc.Run(ctx, time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if clip.reads != 2 {
+		t.Fatalf("expected two clipboard reads across snooze expiry, got %d", clip.reads)
+	}
+	if clip.writes != 1 {
+		t.Fatalf("expected one clipboard write after snooze expiry, got %d", clip.writes)
+	}
+	if clip.value != blockedClipboardValue {
+		t.Fatalf("expected clipboard to be blocked after snooze expiry, got %q", clip.value)
+	}
+	if notifier.calls != 1 {
+		t.Fatalf("expected one notification after snooze expiry, got %d", notifier.calls)
+	}
+	if stateStore.saveCalls != 1 {
+		t.Fatalf("expected expired snooze to be persisted once, got %d saves", stateStore.saveCalls)
+	}
+	if !stateStore.state.SnoozedUntil.IsZero() {
+		t.Fatalf("expected snooze to be cleared after expiry, got %s", stateStore.state.SnoozedUntil)
+	}
+}
+
 func TestScanCurrentDetailedWritesAuditEntry(t *testing.T) {
 	clip := &mockClipboard{value: "start\n-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\nend"}
 	svc := New(config.Defaults(), clip)

--- a/internal/userstate/store.go
+++ b/internal/userstate/store.go
@@ -22,6 +22,18 @@ type State struct {
 	AllowOnce    bool      `json:"allow_once"`
 }
 
+func (s State) ActiveSnoozedUntil(now time.Time) (time.Time, bool) {
+	if s.SnoozedUntil.IsZero() || !s.SnoozedUntil.After(now) {
+		return time.Time{}, false
+	}
+	return s.SnoozedUntil, true
+}
+
+func (s State) SnoozeActive(now time.Time) bool {
+	_, ok := s.ActiveSnoozedUntil(now)
+	return ok
+}
+
 type Store struct {
 	path string
 }


### PR DESCRIPTION
- resume enforcement when snooze expires without requiring a new clipboard or app change
- report expired snooze state correctly in `guardmycopy status`
- add regression coverage and keep CI green

Test results:
- `go test ./...` passed
- `go test -race ./...` passed
- `make ci` passed