### PR TITLE
fix: make launch agent install idempotent

### DIFF
--- a/cmd/guardmycopy/launch_agent.go
+++ b/cmd/guardmycopy/launch_agent.go
@@ -39,6 +39,7 @@ type launchAgentDeps struct {
 	writeFile    func(string, []byte, os.FileMode) error
 	mkdirAll     func(string, os.FileMode) error
 	stat         func(string) (os.FileInfo, error)
+	rename       func(string, string) error
 	remove       func(string) error
 	runLaunchctl func(args ...string) (string, error)
 	activeApp    func() (string, string, error)
@@ -81,6 +82,9 @@ func (d launchAgentDeps) withDefaults() launchAgentDeps {
 	}
 	if d.stat == nil {
 		d.stat = os.Stat
+	}
+	if d.rename == nil {
+		d.rename = os.Rename
 	}
 	if d.remove == nil {
 		d.remove = os.Remove
@@ -310,21 +314,128 @@ func installLaunchAgent(stdout io.Writer, deps launchAgentDeps) error {
 		return fmt.Errorf("plist template still contains placeholders: %s", strings.Join(unresolved, ", "))
 	}
 
-	if err := deps.writeFile(plistPath, []byte(rendered), 0o644); err != nil {
-		return fmt.Errorf("write launch agent plist: %w", err)
+	previousPlist, previousExists, err := readLaunchAgentPlist(deps, plistPath)
+	if err != nil {
+		return err
+	}
+
+	wasLoaded, err := unloadLaunchAgent(deps)
+	if err != nil {
+		return err
+	}
+
+	if err := writeLaunchAgentPlist(plistPath, []byte(rendered), 0o644, deps); err != nil {
+		installErr := fmt.Errorf("write launch agent plist: %w", err)
+		if rollbackErr := rollbackLaunchAgentInstall(plistPath, previousPlist, previousExists, wasLoaded, deps); rollbackErr != nil {
+			return combineLaunchAgentInstallErrors(installErr, rollbackErr)
+		}
+		return installErr
 	}
 
 	domain := launchAgentDomain(deps.uid())
 	out, err := deps.runLaunchctl("bootstrap", domain, plistPath)
 	if err != nil {
-		if strings.TrimSpace(out) != "" {
-			return fmt.Errorf("launchctl bootstrap %s failed: %s (%w)", domain, out, err)
+		installErr := launchctlFailure("bootstrap", domain, out, err)
+		if rollbackErr := rollbackLaunchAgentInstall(plistPath, previousPlist, previousExists, wasLoaded, deps); rollbackErr != nil {
+			return combineLaunchAgentInstallErrors(installErr, rollbackErr)
 		}
-		return fmt.Errorf("launchctl bootstrap %s failed: %w", domain, err)
+		return installErr
 	}
 
 	fmt.Fprintf(stdout, "installed launch agent %q at %s\n", launchAgentLabel, plistPath)
 	return nil
+}
+
+func readLaunchAgentPlist(deps launchAgentDeps, plistPath string) ([]byte, bool, error) {
+	plistBytes, err := deps.readFile(plistPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("read existing launch agent plist: %w", err)
+	}
+	return plistBytes, true, nil
+}
+
+func unloadLaunchAgent(deps launchAgentDeps) (bool, error) {
+	target := launchAgentTarget(deps.uid())
+	out, err := deps.runLaunchctl("bootout", target)
+	if err != nil {
+		if isLaunchctlNotFound(out) {
+			return false, nil
+		}
+		return false, launchctlFailure("bootout", target, out, err)
+	}
+	return true, nil
+}
+
+func rollbackLaunchAgentInstall(plistPath string, previousPlist []byte, previousExists, wasLoaded bool, deps launchAgentDeps) error {
+	if err := restoreLaunchAgentPlist(plistPath, previousPlist, previousExists, deps); err != nil {
+		return err
+	}
+	if !wasLoaded {
+		return nil
+	}
+	if !previousExists {
+		return errors.New("restore previously loaded launch agent: previous plist was missing")
+	}
+
+	domain := launchAgentDomain(deps.uid())
+	out, err := deps.runLaunchctl("bootstrap", domain, plistPath)
+	if err != nil {
+		return launchctlFailure("bootstrap", domain, out, err)
+	}
+	return nil
+}
+
+func restoreLaunchAgentPlist(plistPath string, previousPlist []byte, previousExists bool, deps launchAgentDeps) error {
+	if !previousExists {
+		if err := deps.remove(plistPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove launch agent plist during rollback: %w", err)
+		}
+		return nil
+	}
+
+	if err := writeLaunchAgentPlist(plistPath, previousPlist, 0o644, deps); err != nil {
+		return fmt.Errorf("restore launch agent plist: %w", err)
+	}
+	return nil
+}
+
+func writeLaunchAgentPlist(path string, content []byte, perm os.FileMode, deps launchAgentDeps) error {
+	tempFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	cleanupTemp := true
+	defer func() {
+		if cleanupTemp {
+			_ = deps.remove(tempPath)
+		}
+	}()
+
+	if _, err := tempFile.Write(content); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Chmod(perm); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := deps.rename(tempPath, path); err != nil {
+		return err
+	}
+
+	cleanupTemp = false
+	return nil
+}
+
+func combineLaunchAgentInstallErrors(installErr, rollbackErr error) error {
+	return fmt.Errorf("%w; rollback failed: %v", installErr, rollbackErr)
 }
 
 func (d launchAgentDeps) loadLaunchAgentTemplate() ([]byte, error) {
@@ -373,18 +484,22 @@ func uninstallLaunchAgent(stdout io.Writer, deps launchAgentDeps) error {
 }
 
 func launchAgentStatus(deps launchAgentDeps) (bool, bool, error) {
-	target := fmt.Sprintf("%s/%s", launchAgentDomain(deps.uid()), launchAgentLabel)
+	target := launchAgentTarget(deps.uid())
 	out, err := deps.runLaunchctl("print", target)
 	if err != nil {
 		if isLaunchctlNotFound(out) {
 			return false, false, nil
 		}
-		if strings.TrimSpace(out) != "" {
-			return false, false, fmt.Errorf("launchctl print %s failed: %s (%w)", target, out, err)
-		}
-		return false, false, fmt.Errorf("launchctl print %s failed: %w", target, err)
+		return false, false, launchctlFailure("print", target, out, err)
 	}
 	return true, launchAgentRunning(out), nil
+}
+
+func launchctlFailure(command, target, output string, err error) error {
+	if strings.TrimSpace(output) != "" {
+		return fmt.Errorf("launchctl %s %s failed: %s (%w)", command, target, output, err)
+	}
+	return fmt.Errorf("launchctl %s %s failed: %w", command, target, err)
 }
 
 func launchAgentRunning(output string) bool {
@@ -445,6 +560,10 @@ func isLaunchctlNotFound(output string) bool {
 
 func launchAgentDomain(uid int) string {
 	return fmt.Sprintf("gui/%d", uid)
+}
+
+func launchAgentTarget(uid int) string {
+	return fmt.Sprintf("%s/%s", launchAgentDomain(uid), launchAgentLabel)
 }
 
 func requireDarwinCommand(commandName, runtimeOS string) error {

--- a/cmd/guardmycopy/launch_agent_test.go
+++ b/cmd/guardmycopy/launch_agent_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/rhushab/guardmycopy/internal/userstate"
 )
 
-func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
-	home := t.TempDir()
+func writeLaunchAgentTemplate(t *testing.T) string {
+	t.Helper()
+
 	templatePath := filepath.Join(t.TempDir(), "guardmycopy.plist")
 	template := strings.Join([]string{
 		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
@@ -28,6 +29,30 @@ func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
 	if err := os.WriteFile(templatePath, []byte(template), 0o644); err != nil {
 		t.Fatalf("write template: %v", err)
 	}
+	return templatePath
+}
+
+func installedLaunchAgentPlistPath(home string) string {
+	return filepath.Join(home, "Library", "LaunchAgents", launchAgentLabel+".plist")
+}
+
+func readInstalledLaunchAgentPlist(t *testing.T, home string) string {
+	t.Helper()
+
+	plistBytes, err := os.ReadFile(installedLaunchAgentPlistPath(home))
+	if err != nil {
+		t.Fatalf("read installed plist: %v", err)
+	}
+	return string(plistBytes)
+}
+
+func launchctlServiceNotFoundError() (string, error) {
+	return "Could not find service \"com.guardmycopy.agent\" in domain", errors.New("exit status 113")
+}
+
+func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
+	home := t.TempDir()
+	templatePath := writeLaunchAgentTemplate(t)
 
 	var launchctlCalls [][]string
 	deps := launchAgentDeps{
@@ -47,7 +72,15 @@ func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
 		},
 		runLaunchctl: func(args ...string) (string, error) {
 			launchctlCalls = append(launchctlCalls, append([]string(nil), args...))
-			return "", nil
+			switch args[0] {
+			case "bootout":
+				return launchctlServiceNotFoundError()
+			case "bootstrap":
+				return "", nil
+			default:
+				t.Fatalf("unexpected launchctl args: %q", args)
+				return "", nil
+			}
 		},
 	}
 
@@ -58,12 +91,8 @@ func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
 	}
 
-	plistPath := filepath.Join(home, "Library", "LaunchAgents", launchAgentLabel+".plist")
-	plistBytes, err := os.ReadFile(plistPath)
-	if err != nil {
-		t.Fatalf("read installed plist: %v", err)
-	}
-	plist := string(plistBytes)
+	plistPath := installedLaunchAgentPlistPath(home)
+	plist := readInstalledLaunchAgentPlist(t, home)
 	if strings.Contains(plist, "__GUARDMYCOPY_BIN__") || strings.Contains(plist, "__WORKDIR__") || strings.Contains(plist, "__LOG_DIR__") {
 		t.Fatalf("expected placeholders to be replaced, got %q", plist)
 	}
@@ -78,12 +107,17 @@ func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
 		t.Fatalf("expected log directory to be created: %v", err)
 	}
 
-	if len(launchctlCalls) != 1 {
-		t.Fatalf("expected one launchctl call, got %d", len(launchctlCalls))
+	if len(launchctlCalls) != 2 {
+		t.Fatalf("expected two launchctl calls, got %d", len(launchctlCalls))
 	}
-	expected := []string{"bootstrap", "gui/501", plistPath}
-	if got := strings.Join(launchctlCalls[0], " "); strings.Join(expected, " ") != got {
-		t.Fatalf("unexpected launchctl args: got %q want %q", got, strings.Join(expected, " "))
+	expected := [][]string{
+		{"bootout", launchAgentTarget(501)},
+		{"bootstrap", launchAgentDomain(501), plistPath},
+	}
+	for i := range expected {
+		if got := strings.Join(launchctlCalls[i], " "); strings.Join(expected[i], " ") != got {
+			t.Fatalf("unexpected launchctl args at call %d: got %q want %q", i, got, strings.Join(expected[i], " "))
+		}
 	}
 }
 
@@ -107,12 +141,23 @@ func TestRunInstallWithIOUsesEmbeddedTemplateWhenTemplatePathUnset(t *testing.T)
 			return 501
 		},
 		readFile: func(path string) ([]byte, error) {
-			t.Fatalf("readFile should not be called when templatePath is unset (path=%q)", path)
-			return nil, nil
+			if path == installedLaunchAgentPlistPath(home) {
+				return nil, os.ErrNotExist
+			}
+			t.Fatalf("unexpected readFile call when templatePath is unset (path=%q)", path)
+			return nil, os.ErrNotExist
 		},
 		runLaunchctl: func(args ...string) (string, error) {
 			launchctlCalls = append(launchctlCalls, append([]string(nil), args...))
-			return "", nil
+			switch args[0] {
+			case "bootout":
+				return launchctlServiceNotFoundError()
+			case "bootstrap":
+				return "", nil
+			default:
+				t.Fatalf("unexpected launchctl args: %q", args)
+				return "", nil
+			}
 		},
 	}
 
@@ -123,39 +168,21 @@ func TestRunInstallWithIOUsesEmbeddedTemplateWhenTemplatePathUnset(t *testing.T)
 		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
 	}
 
-	plistPath := filepath.Join(home, "Library", "LaunchAgents", launchAgentLabel+".plist")
-	plistBytes, err := os.ReadFile(plistPath)
-	if err != nil {
-		t.Fatalf("read installed plist: %v", err)
-	}
-	plist := string(plistBytes)
+	plist := readInstalledLaunchAgentPlist(t, home)
 	if !strings.Contains(plist, "/tmp/bin/guardmycopy") {
 		t.Fatalf("expected binary path in plist, got %q", plist)
 	}
 	if !strings.Contains(plist, workDir) {
 		t.Fatalf("expected workdir in plist, got %q", plist)
 	}
-	if len(launchctlCalls) != 1 {
-		t.Fatalf("expected one launchctl call, got %d", len(launchctlCalls))
+	if len(launchctlCalls) != 2 {
+		t.Fatalf("expected two launchctl calls, got %d", len(launchctlCalls))
 	}
 }
 
 func TestRunInstallWithIOEscapesXMLSpecialCharacters(t *testing.T) {
 	home := t.TempDir()
-	templatePath := filepath.Join(t.TempDir(), "guardmycopy.plist")
-	template := strings.Join([]string{
-		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-		"<plist version=\"1.0\">",
-		"<dict>",
-		"<key>Program</key><string>__GUARDMYCOPY_BIN__</string>",
-		"<key>WorkingDirectory</key><string>__WORKDIR__</string>",
-		"<key>StandardOutPath</key><string>__LOG_DIR__/guardmycopy.out.log</string>",
-		"</dict>",
-		"</plist>",
-	}, "\n")
-	if err := os.WriteFile(templatePath, []byte(template), 0o644); err != nil {
-		t.Fatalf("write template: %v", err)
-	}
+	templatePath := writeLaunchAgentTemplate(t)
 
 	deps := launchAgentDeps{
 		runtimeOS:    "darwin",
@@ -173,7 +200,15 @@ func TestRunInstallWithIOEscapesXMLSpecialCharacters(t *testing.T) {
 			return 501
 		},
 		runLaunchctl: func(args ...string) (string, error) {
-			return "", nil
+			switch args[0] {
+			case "bootout":
+				return launchctlServiceNotFoundError()
+			case "bootstrap":
+				return "", nil
+			default:
+				t.Fatalf("unexpected launchctl args: %q", args)
+				return "", nil
+			}
 		},
 	}
 
@@ -184,17 +219,153 @@ func TestRunInstallWithIOEscapesXMLSpecialCharacters(t *testing.T) {
 		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
 	}
 
-	plistPath := filepath.Join(home, "Library", "LaunchAgents", launchAgentLabel+".plist")
-	plistBytes, err := os.ReadFile(plistPath)
-	if err != nil {
-		t.Fatalf("read installed plist: %v", err)
-	}
-	plist := string(plistBytes)
+	plist := readInstalledLaunchAgentPlist(t, home)
 	if !strings.Contains(plist, "/tmp/bin/guard&amp;my&lt;copy&gt;") {
 		t.Fatalf("expected XML-escaped binary path in plist, got %q", plist)
 	}
 	if !strings.Contains(plist, "/tmp/work&amp;dir&lt;prod&gt;") {
 		t.Fatalf("expected XML-escaped workdir in plist, got %q", plist)
+	}
+}
+
+func TestRunInstallWithIOReinstallsLoadedService(t *testing.T) {
+	home := t.TempDir()
+	templatePath := writeLaunchAgentTemplate(t)
+	plistPath := installedLaunchAgentPlistPath(home)
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir plist dir: %v", err)
+	}
+	if err := os.WriteFile(plistPath, []byte("old plist"), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	var launchctlCalls [][]string
+	deps := launchAgentDeps{
+		runtimeOS:    "darwin",
+		templatePath: templatePath,
+		executable: func() (string, error) {
+			return "/tmp/bin/guardmycopy-new", nil
+		},
+		cwd: func() (string, error) {
+			return "/tmp/workdir-new", nil
+		},
+		homeDir: func() (string, error) {
+			return home, nil
+		},
+		uid: func() int {
+			return 501
+		},
+		runLaunchctl: func(args ...string) (string, error) {
+			launchctlCalls = append(launchctlCalls, append([]string(nil), args...))
+			switch args[0] {
+			case "bootout", "bootstrap":
+				return "", nil
+			default:
+				t.Fatalf("unexpected launchctl args: %q", args)
+				return "", nil
+			}
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runInstallWithIO(nil, &stdout, &stderr, deps)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
+	}
+
+	plist := readInstalledLaunchAgentPlist(t, home)
+	if !strings.Contains(plist, "/tmp/bin/guardmycopy-new") {
+		t.Fatalf("expected updated binary path in plist, got %q", plist)
+	}
+	if !strings.Contains(plist, "/tmp/workdir-new") {
+		t.Fatalf("expected updated workdir in plist, got %q", plist)
+	}
+	if len(launchctlCalls) != 2 {
+		t.Fatalf("expected two launchctl calls, got %d", len(launchctlCalls))
+	}
+	expected := [][]string{
+		{"bootout", launchAgentTarget(501)},
+		{"bootstrap", launchAgentDomain(501), plistPath},
+	}
+	for i := range expected {
+		if got := strings.Join(launchctlCalls[i], " "); strings.Join(expected[i], " ") != got {
+			t.Fatalf("unexpected launchctl args at call %d: got %q want %q", i, got, strings.Join(expected[i], " "))
+		}
+	}
+}
+
+func TestRunInstallWithIORollsBackPlistWhenReloadFails(t *testing.T) {
+	home := t.TempDir()
+	templatePath := writeLaunchAgentTemplate(t)
+	plistPath := installedLaunchAgentPlistPath(home)
+	if err := os.MkdirAll(filepath.Dir(plistPath), 0o755); err != nil {
+		t.Fatalf("mkdir plist dir: %v", err)
+	}
+	originalPlist := "original plist"
+	if err := os.WriteFile(plistPath, []byte(originalPlist), 0o644); err != nil {
+		t.Fatalf("write existing plist: %v", err)
+	}
+
+	var launchctlCalls [][]string
+	bootstrapCalls := 0
+	deps := launchAgentDeps{
+		runtimeOS:    "darwin",
+		templatePath: templatePath,
+		executable: func() (string, error) {
+			return "/tmp/bin/guardmycopy-new", nil
+		},
+		cwd: func() (string, error) {
+			return "/tmp/workdir-new", nil
+		},
+		homeDir: func() (string, error) {
+			return home, nil
+		},
+		uid: func() int {
+			return 501
+		},
+		runLaunchctl: func(args ...string) (string, error) {
+			launchctlCalls = append(launchctlCalls, append([]string(nil), args...))
+			switch args[0] {
+			case "bootout":
+				return "", nil
+			case "bootstrap":
+				bootstrapCalls++
+				if bootstrapCalls == 1 {
+					return "bootstrap failed", errors.New("exit status 5")
+				}
+				return "", nil
+			default:
+				t.Fatalf("unexpected launchctl args: %q", args)
+				return "", nil
+			}
+		},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := runInstallWithIO(nil, &stdout, &stderr, deps)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "launchctl bootstrap gui/501 failed: bootstrap failed") {
+		t.Fatalf("expected bootstrap failure in stderr, got %q", stderr.String())
+	}
+	if got := readInstalledLaunchAgentPlist(t, home); got != originalPlist {
+		t.Fatalf("expected plist rollback to preserve original content, got %q", got)
+	}
+	if len(launchctlCalls) != 3 {
+		t.Fatalf("expected three launchctl calls, got %d", len(launchctlCalls))
+	}
+	expected := [][]string{
+		{"bootout", launchAgentTarget(501)},
+		{"bootstrap", launchAgentDomain(501), plistPath},
+		{"bootstrap", launchAgentDomain(501), plistPath},
+	}
+	for i := range expected {
+		if got := strings.Join(launchctlCalls[i], " "); strings.Join(expected[i], " ") != got {
+			t.Fatalf("unexpected launchctl args at call %d: got %q want %q", i, got, strings.Join(expected[i], " "))
+		}
 	}
 }
 


### PR DESCRIPTION
- make `guardmycopy install` safe to rerun during upgrades or path changes
- keep plist and loaded launch-agent state consistent on failures
- add regression tests for reinstall behavior

## Test results
- `go test ./...`
- `make ci`