### PR TITLE
Fix launch agent install and uninstall reliability

### DIFF
--- a/cmd/guardmycopy/guardmycopy.plist
+++ b/cmd/guardmycopy/guardmycopy.plist
@@ -6,10 +6,9 @@ Template LaunchAgent for guardmycopy.
 Manual setup (not automatic):
 1) Copy this file to ~/Library/LaunchAgents/com.guardmycopy.agent.plist
 2) Replace __GUARDMYCOPY_BIN__ with the absolute path to the guardmycopy binary.
-3) Replace __WORKDIR__ with your project directory.
-4) Replace __LOG_DIR__ with a writable directory for logs.
-5) Load it: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.guardmycopy.agent.plist
-6) Verify: launchctl print gui/$(id -u)/com.guardmycopy.agent
+3) Replace __LOG_DIR__ with a writable directory for logs.
+4) Load it: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.guardmycopy.agent.plist
+5) Verify: launchctl print gui/$(id -u)/com.guardmycopy.agent
 
 Disable/remove:
 - launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.guardmycopy.agent.plist
@@ -27,9 +26,6 @@ Disable/remove:
     <string>--interval</string>
     <string>500</string>
   </array>
-
-  <key>WorkingDirectory</key>
-  <string>__WORKDIR__</string>
 
   <key>RunAtLoad</key>
   <true/>

--- a/cmd/guardmycopy/launch_agent.go
+++ b/cmd/guardmycopy/launch_agent.go
@@ -32,7 +32,6 @@ type launchAgentDeps struct {
 	templateData []byte
 	timeNow      func() time.Time
 	executable   func() (string, error)
-	cwd          func() (string, error)
 	homeDir      func() (string, error)
 	uid          func() int
 	readFile     func(string) ([]byte, error)
@@ -61,9 +60,6 @@ func (d launchAgentDeps) withDefaults() launchAgentDeps {
 	}
 	if d.executable == nil {
 		d.executable = os.Executable
-	}
-	if d.cwd == nil {
-		d.cwd = os.Getwd
 	}
 	if d.homeDir == nil {
 		d.homeDir = os.UserHomeDir
@@ -276,21 +272,9 @@ func installLaunchAgent(stdout io.Writer, deps launchAgentDeps) error {
 	if err != nil {
 		return fmt.Errorf("make executable path absolute: %w", err)
 	}
-	workDir, err := deps.cwd()
-	if err != nil {
-		return fmt.Errorf("resolve working directory: %w", err)
-	}
-	workDir, err = filepath.Abs(workDir)
-	if err != nil {
-		return fmt.Errorf("make working directory absolute: %w", err)
-	}
 	xmlBinPath, err := escapeXMLText(binPath)
 	if err != nil {
 		return fmt.Errorf("escape executable path for plist: %w", err)
-	}
-	xmlWorkDir, err := escapeXMLText(workDir)
-	if err != nil {
-		return fmt.Errorf("escape working directory for plist: %w", err)
 	}
 	xmlLogDir, err := escapeXMLText(logDir)
 	if err != nil {
@@ -304,11 +288,31 @@ func installLaunchAgent(stdout io.Writer, deps launchAgentDeps) error {
 		return fmt.Errorf("create log directory: %w", err)
 	}
 
-	rendered := strings.NewReplacer(
+	replacements := []string{
 		"__GUARDMYCOPY_BIN__", xmlBinPath,
-		"__WORKDIR__", xmlWorkDir,
 		"__LOG_DIR__", xmlLogDir,
-	).Replace(string(templateBytes))
+	}
+	if strings.Contains(string(templateBytes), "__WORKDIR__") {
+		stableWorkDir, err := deps.homeDir()
+		if err != nil {
+			return fmt.Errorf("resolve stable working directory: %w", err)
+		}
+		stableWorkDir = strings.TrimSpace(stableWorkDir)
+		if stableWorkDir == "" {
+			return errors.New("resolve stable working directory: empty path")
+		}
+		stableWorkDir, err = filepath.Abs(stableWorkDir)
+		if err != nil {
+			return fmt.Errorf("make stable working directory absolute: %w", err)
+		}
+		xmlWorkDir, err := escapeXMLText(stableWorkDir)
+		if err != nil {
+			return fmt.Errorf("escape stable working directory for plist: %w", err)
+		}
+		replacements = append(replacements, "__WORKDIR__", xmlWorkDir)
+	}
+
+	rendered := strings.NewReplacer(replacements...).Replace(string(templateBytes))
 
 	if unresolved := unresolvedTemplatePlaceholders(rendered); len(unresolved) > 0 {
 		return fmt.Errorf("plist template still contains placeholders: %s", strings.Join(unresolved, ", "))
@@ -458,21 +462,18 @@ func uninstallLaunchAgent(stdout io.Writer, deps launchAgentDeps) error {
 		return err
 	}
 
+	target := launchAgentTarget(deps.uid())
+	out, err := deps.runLaunchctl("bootout", target)
+	if err != nil && !isLaunchctlNotFound(out) {
+		return launchctlFailure("bootout", target, out, err)
+	}
+
 	if _, err := deps.stat(plistPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			fmt.Fprintf(stdout, "launch agent plist not found at %s\n", plistPath)
 			return nil
 		}
 		return fmt.Errorf("stat launch agent plist: %w", err)
-	}
-
-	domain := launchAgentDomain(deps.uid())
-	out, err := deps.runLaunchctl("bootout", domain, plistPath)
-	if err != nil && !isLaunchctlNotFound(out) {
-		if strings.TrimSpace(out) != "" {
-			return fmt.Errorf("launchctl bootout %s failed: %s (%w)", domain, out, err)
-		}
-		return fmt.Errorf("launchctl bootout %s failed: %w", domain, err)
 	}
 
 	if err := deps.remove(plistPath); err != nil && !errors.Is(err, os.ErrNotExist) {

--- a/cmd/guardmycopy/launch_agent_test.go
+++ b/cmd/guardmycopy/launch_agent_test.go
@@ -21,13 +21,32 @@ func writeLaunchAgentTemplate(t *testing.T) string {
 		"<plist version=\"1.0\">",
 		"<dict>",
 		"<key>Program</key><string>__GUARDMYCOPY_BIN__</string>",
-		"<key>WorkingDirectory</key><string>__WORKDIR__</string>",
 		"<key>StandardOutPath</key><string>__LOG_DIR__/guardmycopy.out.log</string>",
 		"</dict>",
 		"</plist>",
 	}, "\n")
 	if err := os.WriteFile(templatePath, []byte(template), 0o644); err != nil {
 		t.Fatalf("write template: %v", err)
+	}
+	return templatePath
+}
+
+func writeLegacyLaunchAgentTemplate(t *testing.T) string {
+	t.Helper()
+
+	templatePath := filepath.Join(t.TempDir(), "guardmycopy-legacy.plist")
+	template := strings.Join([]string{
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+		"<plist version=\"1.0\">",
+		"<dict>",
+		"<key>Program</key><string>__GUARDMYCOPY_BIN__</string>",
+		"<key>WorkingDirectory</key><string>__WORKDIR__</string>",
+		"<key>StandardOutPath</key><string>__LOG_DIR__/guardmycopy.out.log</string>",
+		"</dict>",
+		"</plist>",
+	}, "\n")
+	if err := os.WriteFile(templatePath, []byte(template), 0o644); err != nil {
+		t.Fatalf("write legacy template: %v", err)
 	}
 	return templatePath
 }
@@ -60,9 +79,6 @@ func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
 		templatePath: templatePath,
 		executable: func() (string, error) {
 			return "/tmp/bin/guardmycopy", nil
-		},
-		cwd: func() (string, error) {
-			return "/tmp/workdir", nil
 		},
 		homeDir: func() (string, error) {
 			return home, nil
@@ -99,8 +115,8 @@ func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
 	if !strings.Contains(plist, "/tmp/bin/guardmycopy") {
 		t.Fatalf("expected binary path in plist, got %q", plist)
 	}
-	if !strings.Contains(plist, "/tmp/workdir") {
-		t.Fatalf("expected workdir in plist, got %q", plist)
+	if strings.Contains(plist, "WorkingDirectory") {
+		t.Fatalf("expected plist to omit working directory, got %q", plist)
 	}
 	logDir := filepath.Join(home, "Library", "Logs", "guardmycopy")
 	if _, err := os.Stat(logDir); err != nil {
@@ -123,16 +139,12 @@ func TestRunInstallWithIOWritesPlistAndBootstraps(t *testing.T) {
 
 func TestRunInstallWithIOUsesEmbeddedTemplateWhenTemplatePathUnset(t *testing.T) {
 	home := t.TempDir()
-	workDir := t.TempDir()
 
 	var launchctlCalls [][]string
 	deps := launchAgentDeps{
 		runtimeOS: "darwin",
 		executable: func() (string, error) {
 			return "/tmp/bin/guardmycopy", nil
-		},
-		cwd: func() (string, error) {
-			return workDir, nil
 		},
 		homeDir: func() (string, error) {
 			return home, nil
@@ -172,26 +184,23 @@ func TestRunInstallWithIOUsesEmbeddedTemplateWhenTemplatePathUnset(t *testing.T)
 	if !strings.Contains(plist, "/tmp/bin/guardmycopy") {
 		t.Fatalf("expected binary path in plist, got %q", plist)
 	}
-	if !strings.Contains(plist, workDir) {
-		t.Fatalf("expected workdir in plist, got %q", plist)
+	if strings.Contains(plist, "WorkingDirectory") {
+		t.Fatalf("expected embedded template to omit working directory, got %q", plist)
 	}
 	if len(launchctlCalls) != 2 {
 		t.Fatalf("expected two launchctl calls, got %d", len(launchctlCalls))
 	}
 }
 
-func TestRunInstallWithIOEscapesXMLSpecialCharacters(t *testing.T) {
-	home := t.TempDir()
-	templatePath := writeLaunchAgentTemplate(t)
+func TestRunInstallWithIOLegacyWorkingDirectoryPlaceholderUsesHomeDir(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "stable&home<dir>")
+	templatePath := writeLegacyLaunchAgentTemplate(t)
 
 	deps := launchAgentDeps{
 		runtimeOS:    "darwin",
 		templatePath: templatePath,
 		executable: func() (string, error) {
 			return "/tmp/bin/guard&my<copy>", nil
-		},
-		cwd: func() (string, error) {
-			return "/tmp/work&dir<prod>", nil
 		},
 		homeDir: func() (string, error) {
 			return home, nil
@@ -223,8 +232,14 @@ func TestRunInstallWithIOEscapesXMLSpecialCharacters(t *testing.T) {
 	if !strings.Contains(plist, "/tmp/bin/guard&amp;my&lt;copy&gt;") {
 		t.Fatalf("expected XML-escaped binary path in plist, got %q", plist)
 	}
-	if !strings.Contains(plist, "/tmp/work&amp;dir&lt;prod&gt;") {
-		t.Fatalf("expected XML-escaped workdir in plist, got %q", plist)
+	if !strings.Contains(plist, "WorkingDirectory") {
+		t.Fatalf("expected legacy template working directory to be preserved, got %q", plist)
+	}
+	if !strings.Contains(plist, "stable&amp;home&lt;dir&gt;") {
+		t.Fatalf("expected legacy workdir placeholder to use XML-escaped home dir, got %q", plist)
+	}
+	if strings.Contains(plist, "work&amp;dir") {
+		t.Fatalf("expected install to avoid caller cwd, got %q", plist)
 	}
 }
 
@@ -245,9 +260,6 @@ func TestRunInstallWithIOReinstallsLoadedService(t *testing.T) {
 		templatePath: templatePath,
 		executable: func() (string, error) {
 			return "/tmp/bin/guardmycopy-new", nil
-		},
-		cwd: func() (string, error) {
-			return "/tmp/workdir-new", nil
 		},
 		homeDir: func() (string, error) {
 			return home, nil
@@ -278,8 +290,8 @@ func TestRunInstallWithIOReinstallsLoadedService(t *testing.T) {
 	if !strings.Contains(plist, "/tmp/bin/guardmycopy-new") {
 		t.Fatalf("expected updated binary path in plist, got %q", plist)
 	}
-	if !strings.Contains(plist, "/tmp/workdir-new") {
-		t.Fatalf("expected updated workdir in plist, got %q", plist)
+	if strings.Contains(plist, "WorkingDirectory") {
+		t.Fatalf("expected reinstalled plist to omit working directory, got %q", plist)
 	}
 	if len(launchctlCalls) != 2 {
 		t.Fatalf("expected two launchctl calls, got %d", len(launchctlCalls))
@@ -314,9 +326,6 @@ func TestRunInstallWithIORollsBackPlistWhenReloadFails(t *testing.T) {
 		templatePath: templatePath,
 		executable: func() (string, error) {
 			return "/tmp/bin/guardmycopy-new", nil
-		},
-		cwd: func() (string, error) {
-			return "/tmp/workdir-new", nil
 		},
 		homeDir: func() (string, error) {
 			return home, nil
@@ -426,21 +435,25 @@ func TestRunUninstallWithIORunsBootoutAndRemovesPlist(t *testing.T) {
 	if len(launchctlCalls) != 1 {
 		t.Fatalf("expected one launchctl call, got %d", len(launchctlCalls))
 	}
-	expected := []string{"bootout", "gui/777", plistPath}
+	expected := []string{"bootout", launchAgentTarget(777)}
 	if got := strings.Join(launchctlCalls[0], " "); strings.Join(expected, " ") != got {
 		t.Fatalf("unexpected launchctl args: got %q want %q", got, strings.Join(expected, " "))
 	}
 }
 
-func TestRunUninstallWithIOMissingPlistSkipsBootout(t *testing.T) {
+func TestRunUninstallWithIOMissingPlistStillBootsOutService(t *testing.T) {
 	home := t.TempDir()
+	var launchctlCalls [][]string
 	deps := launchAgentDeps{
 		runtimeOS: "darwin",
 		homeDir: func() (string, error) {
 			return home, nil
 		},
+		uid: func() int {
+			return 777
+		},
 		runLaunchctl: func(args ...string) (string, error) {
-			t.Fatal("launchctl should not be called when plist is missing")
+			launchctlCalls = append(launchctlCalls, append([]string(nil), args...))
 			return "", nil
 		},
 	}
@@ -450,6 +463,13 @@ func TestRunUninstallWithIOMissingPlistSkipsBootout(t *testing.T) {
 	code := runUninstallWithIO(nil, &stdout, &stderr, deps)
 	if code != 0 {
 		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	if len(launchctlCalls) != 1 {
+		t.Fatalf("expected one launchctl call, got %d", len(launchctlCalls))
+	}
+	expected := []string{"bootout", launchAgentTarget(777)}
+	if got := strings.Join(launchctlCalls[0], " "); strings.Join(expected, " ") != got {
+		t.Fatalf("unexpected launchctl args: got %q want %q", got, strings.Join(expected, " "))
 	}
 	if !strings.Contains(stdout.String(), "not found") {
 		t.Fatalf("expected not found message, got %q", stdout.String())

--- a/scripts/macos/guardmycopy.plist
+++ b/scripts/macos/guardmycopy.plist
@@ -6,10 +6,9 @@ Template LaunchAgent for guardmycopy.
 Manual setup (not automatic):
 1) Copy this file to ~/Library/LaunchAgents/com.guardmycopy.agent.plist
 2) Replace __GUARDMYCOPY_BIN__ with the absolute path to the guardmycopy binary.
-3) Replace __WORKDIR__ with your project directory.
-4) Replace __LOG_DIR__ with a writable directory for logs.
-5) Load it: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.guardmycopy.agent.plist
-6) Verify: launchctl print gui/$(id -u)/com.guardmycopy.agent
+3) Replace __LOG_DIR__ with a writable directory for logs.
+4) Load it: launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.guardmycopy.agent.plist
+5) Verify: launchctl print gui/$(id -u)/com.guardmycopy.agent
 
 Disable/remove:
 - launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.guardmycopy.agent.plist
@@ -27,9 +26,6 @@ Disable/remove:
     <string>--interval</string>
     <string>500</string>
   </array>
-
-  <key>WorkingDirectory</key>
-  <string>__WORKDIR__</string>
 
   <key>RunAtLoad</key>
   <true/>


### PR DESCRIPTION
## Summary
- stop embedding the install-time working directory in the launch agent templates
- keep legacy __WORKDIR__ templates working by resolving that placeholder to a stable home directory
- always boot out the launch agent service during uninstall, even if the plist was already removed

## Testing
- go test ./cmd/guardmycopy -run 'LaunchAgent|RunInstall|RunUninstall|RunStatus'
- go test ./...
- go vet ./...
- go test -race ./...
- go run honnef.co/go/tools/cmd/staticcheck@latest ./...