### PR TITLE
Fix runtime state writes and clipboard recovery

### DIFF
--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -251,7 +251,9 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 		case <-timer.C:
 			currentChangeCount, hasChangeCount, err := s.currentClipboardChangeCount()
 			if err != nil {
-				return err
+				s.warnRuntime("clipboard-change-count", "clipboard change count unavailable; falling back to full clipboard reads: %v", err)
+				currentChangeCount = 0
+				hasChangeCount = false
 			}
 			state, err := s.loadRuntimeState()
 			if err != nil {
@@ -274,7 +276,9 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 
 			current, err := s.clipboard.ReadText()
 			if err != nil {
-				return fmt.Errorf("read clipboard: %w", err)
+				s.warnRuntime("clipboard-read", "clipboard read failed; retrying: %v", err)
+				timer.Reset(polling.OnClipboardChanged())
+				continue
 			}
 			currentHash := hashText(current)
 			if !appResolutionLoaded {
@@ -334,7 +338,8 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 				lastSeenHash = hashText(nextValue)
 				currentChangeCount, hasChangeCount, err = s.currentClipboardChangeCount()
 				if err != nil {
-					return err
+					s.warnRuntime("clipboard-change-count", "clipboard change count unavailable after clipboard update; continuing without fast-path optimization: %v", err)
+					hasChangeCount = false
 				}
 				if hasChangeCount {
 					lastSeenChangeCount = currentChangeCount

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -439,6 +439,88 @@ func TestRunStopsWhenContextCanceled(t *testing.T) {
 	}
 }
 
+func TestRunContinuesAfterTransientClipboardChangeCountFailure(t *testing.T) {
+	clip := &mockClipboardWithChangeDetector{
+		mockClipboard: &mockClipboard{
+			value: "start\n-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\nend",
+		},
+		changeCountErr: errors.New("pasteboard temporarily unavailable"),
+	}
+	clip.changeCountHook = func(call int) {
+		if call > 1 {
+			clip.changeCountErr = nil
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clip.readHook = func() {
+		cancel()
+		clip.readHook = nil
+	}
+
+	var warnings bytes.Buffer
+	svc := New(config.Defaults(), clip)
+	svc.SetWarningOutput(&warnings)
+
+	err := svc.Run(ctx, time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if clip.reads != 1 {
+		t.Fatalf("expected one clipboard read after change count failure, got %d", clip.reads)
+	}
+	if clip.writes != 1 {
+		t.Fatalf("expected enforcement to continue after change count failure, got %d writes", clip.writes)
+	}
+	if !strings.Contains(warnings.String(), "clipboard change count unavailable") {
+		t.Fatalf("expected change count warning, got %q", warnings.String())
+	}
+}
+
+func TestRunContinuesAfterTransientClipboardReadFailure(t *testing.T) {
+	clip := &mockClipboard{
+		value: "start\n-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\nend",
+	}
+	clip.readHook = func() {
+		switch clip.reads {
+		case 1:
+			clip.readErr = errors.New("pasteboard temporarily unavailable")
+		default:
+			clip.readErr = nil
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	initialHook := clip.readHook
+	clip.readHook = func() {
+		initialHook()
+		if clip.reads == 2 {
+			cancel()
+			clip.readHook = nil
+		}
+	}
+
+	var warnings bytes.Buffer
+	svc := New(config.Defaults(), clip)
+	svc.SetWarningOutput(&warnings)
+
+	err := svc.Run(ctx, time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if clip.reads != 2 {
+		t.Fatalf("expected run to retry after read failure, got %d reads", clip.reads)
+	}
+	if clip.writes != 1 {
+		t.Fatalf("expected enforcement after retry, got %d writes", clip.writes)
+	}
+	if !strings.Contains(warnings.String(), "clipboard read failed; retrying") {
+		t.Fatalf("expected clipboard read warning, got %q", warnings.String())
+	}
+}
+
 func TestShouldBypassEnforcementSnoozed(t *testing.T) {
 	clip := &mockClipboard{value: "secret"}
 	svc := New(config.Defaults(), clip)

--- a/internal/userstate/store.go
+++ b/internal/userstate/store.go
@@ -95,9 +95,45 @@ func (s *Store) Save(state State) error {
 	}
 	payload = append(payload, '\n')
 
-	if err := os.WriteFile(s.path, payload, defaultStateFileMode); err != nil {
+	if err := writeFileAtomically(s.path, payload, defaultStateFileMode); err != nil {
 		return fmt.Errorf("write state file: %w", err)
 	}
 
+	return nil
+}
+
+func writeFileAtomically(path string, content []byte, perm os.FileMode) error {
+	tempFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tempPath := tempFile.Name()
+	cleanupTemp := true
+	defer func() {
+		if cleanupTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if _, err := tempFile.Write(content); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Chmod(perm); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Sync(); err != nil {
+		_ = tempFile.Close()
+		return err
+	}
+	if err := tempFile.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return err
+	}
+
+	cleanupTemp = false
 	return nil
 }

--- a/internal/userstate/store_test.go
+++ b/internal/userstate/store_test.go
@@ -81,3 +81,41 @@ func TestStoreSaveUsesPrivatePermissions(t *testing.T) {
 		t.Fatalf("expected private state file permissions, got %o", got)
 	}
 }
+
+func TestStoreSaveOverwritesExistingStateWithoutTempLeak(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	store, err := New(path)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if err := store.Save(State{AllowOnce: true}); err != nil {
+		t.Fatalf("first Save returned error: %v", err)
+	}
+
+	want := State{
+		SnoozedUntil: time.Unix(1_700_000_100, 0).UTC(),
+	}
+	if err := store.Save(want); err != nil {
+		t.Fatalf("second Save returned error: %v", err)
+	}
+
+	got, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if !got.SnoozedUntil.Equal(want.SnoozedUntil) {
+		t.Fatalf("unexpected snoozed_until: got %s want %s", got.SnoozedUntil, want.SnoozedUntil)
+	}
+	if got.AllowOnce {
+		t.Fatal("expected allow_once to be overwritten")
+	}
+
+	matches, err := filepath.Glob(path + ".tmp-*")
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no temporary state files, found %v", matches)
+	}
+}


### PR DESCRIPTION
## Summary
- make runtime state saves atomic so concurrent snooze/allow-once updates cannot expose partial JSON to the daemon
- keep the run loop alive across transient clipboard change-count and read failures by warning and retrying
- add regression tests for both retry behavior and repeated state saves

## Testing
- go test ./...
- go test -race ./...
- go vet ./...
- staticcheck ./...