### PR TITLE
Fix allow-once startup semantics and launch agent poll interval

### DIFF
--- a/cmd/guardmycopy/guardmycopy.plist
+++ b/cmd/guardmycopy/guardmycopy.plist
@@ -23,8 +23,6 @@ Disable/remove:
   <array>
     <string>__GUARDMYCOPY_BIN__</string>
     <string>run</string>
-    <string>--interval</string>
-    <string>500</string>
   </array>
 
   <key>RunAtLoad</key>

--- a/cmd/guardmycopy/launch_agent_test.go
+++ b/cmd/guardmycopy/launch_agent_test.go
@@ -184,11 +184,33 @@ func TestRunInstallWithIOUsesEmbeddedTemplateWhenTemplatePathUnset(t *testing.T)
 	if !strings.Contains(plist, "/tmp/bin/guardmycopy") {
 		t.Fatalf("expected binary path in plist, got %q", plist)
 	}
+	if strings.Contains(plist, "<string>--interval</string>") {
+		t.Fatalf("expected embedded template to honor config poll interval, got %q", plist)
+	}
 	if strings.Contains(plist, "WorkingDirectory") {
 		t.Fatalf("expected embedded template to omit working directory, got %q", plist)
 	}
 	if len(launchctlCalls) != 2 {
 		t.Fatalf("expected two launchctl calls, got %d", len(launchctlCalls))
+	}
+}
+
+func TestShippedLaunchAgentTemplatesDoNotHardcodeInterval(t *testing.T) {
+	paths := []string{
+		"guardmycopy.plist",
+		filepath.Join("..", "..", "scripts", "macos", "guardmycopy.plist"),
+	}
+
+	for _, path := range paths {
+		templateBytes, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read template %q: %v", path, err)
+		}
+
+		template := string(templateBytes)
+		if strings.Contains(template, "<string>--interval</string>") {
+			t.Fatalf("expected template %q to rely on config poll interval, got %q", path, template)
+		}
 	}
 }
 

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -285,6 +285,7 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 			clipboardOrAppChanged := !seen ||
 				currentHash != lastSeenHash ||
 				appResolution.context != lastSeenAppContext
+			allowOnceEligible := seen && clipboardOrAppChanged
 			if !clipboardOrAppChanged && snoozeActive == lastSeenSnoozeActive {
 				if hasChangeCount {
 					lastSeenChangeCount = currentChangeCount
@@ -306,7 +307,7 @@ func (s *Service) Run(ctx context.Context, interval time.Duration) error {
 			}
 			nextInterval := polling.OnClipboardChanged()
 
-			bypass, bypassReason := s.shouldBypassEnforcementForRun(state, clipboardOrAppChanged)
+			bypass, bypassReason := s.shouldBypassEnforcementForRun(state, allowOnceEligible)
 			if bypass {
 				s.logVerbose("action=allow reason=%s", bypassReason)
 				timer.Reset(nextInterval)

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -647,7 +647,7 @@ func TestRunDoesNotRepeatAllowOnceBypassAfterSaveFailure(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	clip.readHook = func() {
-		if clip.reads == 3 {
+		if clip.reads == 4 {
 			cancel()
 			clip.readHook = nil
 		}
@@ -735,7 +735,7 @@ func TestShouldBypassEnforcementConsumesAllowOnce(t *testing.T) {
 	}
 }
 
-func TestRunRespectsAllowOnceState(t *testing.T) {
+func TestRunDoesNotConsumeAllowOnceOnInitialScan(t *testing.T) {
 	clip := &mockClipboard{value: "start\n-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\nend"}
 	svc := New(config.Defaults(), clip)
 
@@ -756,11 +756,64 @@ func TestRunRespectsAllowOnceState(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("expected context canceled, got %v", err)
 	}
-	if clip.writes != 0 {
-		t.Fatalf("expected run to skip enforcement due to allow-once, writes=%d", clip.writes)
+	if clip.writes != 1 {
+		t.Fatalf("expected initial scan to keep enforcing, writes=%d", clip.writes)
+	}
+	if !stateStore.state.AllowOnce {
+		t.Fatal("expected allow_once to remain pending until the next change")
+	}
+}
+
+func TestRunConsumesAllowOnceOnNextObservedChange(t *testing.T) {
+	clip := &mockClipboardWithChangeDetector{
+		mockClipboard: &mockClipboard{value: "hello"},
+		changeCounts:  []int64{1, 2, 2},
+	}
+	clip.changeCountHook = func(call int) {
+		if call == 2 {
+			clip.value = "start\n-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\nend"
+		}
+	}
+
+	foregroundCalls := 0
+	foreground := &mockForegroundApp{
+		activeApp: func() (string, string, error) {
+			foregroundCalls++
+			if foregroundCalls < 3 {
+				return "Slack", "com.tinyspeck.slackmacgap", nil
+			}
+			return "Terminal", "com.apple.Terminal", nil
+		},
+	}
+
+	stateStore := &mockRuntimeStateStore{
+		state: userstate.State{
+			AllowOnce: true,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	clip.writeHook = func(attempt int) {
+		cancel()
+		clip.writeHook = nil
+	}
+
+	svc := NewWithDependencies(config.Defaults(), clip, foreground, nil)
+	svc.SetRuntimeStateStore(stateStore)
+
+	err := svc.Run(ctx, time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled, got %v", err)
+	}
+	if clip.reads != 3 {
+		t.Fatalf("expected three clipboard reads across baseline, bypass, and reenforcement, got %d", clip.reads)
+	}
+	if clip.writes != 1 {
+		t.Fatalf("expected one clipboard write after allow_once was consumed, got %d", clip.writes)
 	}
 	if stateStore.state.AllowOnce {
-		t.Fatal("expected allow_once to be consumed during run")
+		t.Fatal("expected allow_once to be consumed on the next observed change")
 	}
 }
 

--- a/scripts/macos/guardmycopy.plist
+++ b/scripts/macos/guardmycopy.plist
@@ -23,8 +23,6 @@ Disable/remove:
   <array>
     <string>__GUARDMYCOPY_BIN__</string>
     <string>run</string>
-    <string>--interval</string>
-    <string>500</string>
   </array>
 
   <key>RunAtLoad</key>


### PR DESCRIPTION
## Summary
- keep `allow-once` pending through the initial startup scan and consume it only on the next observed clipboard/app change
- remove the hardcoded `--interval 500` override from both shipped launch-agent plists so background runs honor `global.poll_interval_ms`
- add regression coverage for the new allow-once semantics and launch-agent templates

## Testing
- go test ./...
- go test -race ./...
- go vet ./...
